### PR TITLE
[ #5 ] join feature 피드백 반영

### DIFF
--- a/src/main/java/com/flab/urlumberjack/global/Utils/QueryUtil.java
+++ b/src/main/java/com/flab/urlumberjack/global/Utils/QueryUtil.java
@@ -1,0 +1,16 @@
+package com.flab.urlumberjack.global.Utils;
+
+import java.util.Objects;
+
+public class QueryUtil {
+
+	/**
+	 * insert가 정상적으로 수행되었는지에 대해 반환합니다.
+	 * @param insertResult (int) insert 쿼리의 결과값
+	 * @return insert가 정상적으로 수행되었다면 true, 아니라면 false를 반환합니다.
+	 */
+	public static boolean excuteInsertQuery(Integer insertResult) {
+		return !Objects.equals(insertResult, 0);
+	}
+
+}

--- a/src/main/java/com/flab/urlumberjack/global/jwt/UserDetail.java
+++ b/src/main/java/com/flab/urlumberjack/global/jwt/UserDetail.java
@@ -26,7 +26,7 @@ public class UserDetail implements UserDetails {
 
 	@Override
 	public String getPassword() {
-		return user.getPw();
+		return user.getPassword();
 	}
 
 	@Override

--- a/src/main/java/com/flab/urlumberjack/user/controller/UserController.java
+++ b/src/main/java/com/flab/urlumberjack/user/controller/UserController.java
@@ -24,7 +24,7 @@ public class UserController {
 		this.service = service;
 	}
 
-	@PostMapping("/join")
+	@PostMapping
 	public ResponseEntity<JoinResponse> join(@RequestBody @Valid JoinRequest dto) {
 		return ResponseEntity.ok(service.join(dto));
 	}

--- a/src/main/java/com/flab/urlumberjack/user/domain/User.java
+++ b/src/main/java/com/flab/urlumberjack/user/domain/User.java
@@ -9,17 +9,17 @@ import lombok.NoArgsConstructor;
 public class User {
 	private Long tid;
 	private String email;
-	private String pw;
+	private String password;
 	private String mdn;
-	private String type;
+	private UserJoinType type;
 	private Role role;
-	private Status status;
+	private UserAccountStatus status;
 
 	//UserServiceTest를 위한 User객체 생성 메소드
-	public static User of(String email, String pw, String mdn) {
+	public static User of(String email, String password, String mdn) {
 		User user = new User();
 		user.email = email;
-		user.pw = pw;
+		user.password = password;
 		user.mdn = mdn;
 		return user;
 	}

--- a/src/main/java/com/flab/urlumberjack/user/domain/UserAccountStatus.java
+++ b/src/main/java/com/flab/urlumberjack/user/domain/UserAccountStatus.java
@@ -1,5 +1,5 @@
 package com.flab.urlumberjack.user.domain;
 
-public enum Status {
+public enum UserAccountStatus {
 	ACTIVE, INACTIVE, DELETE
 }

--- a/src/main/java/com/flab/urlumberjack/user/domain/UserJoinType.java
+++ b/src/main/java/com/flab/urlumberjack/user/domain/UserJoinType.java
@@ -1,5 +1,5 @@
 package com.flab.urlumberjack.user.domain;
 
-public enum Type {
+public enum UserJoinType {
 	DEFAULT, GOOGLE, NAVER, KAKAO
 }

--- a/src/main/java/com/flab/urlumberjack/user/dto/request/JoinRequest.java
+++ b/src/main/java/com/flab/urlumberjack/user/dto/request/JoinRequest.java
@@ -25,7 +25,8 @@ public class JoinRequest {
 		message = "올바른 전화번호를 입력해 주세요.")
 	String mdn;
 
-	String type;
+	//기본값은 DEFAULT 입니다. (직접 회원가입)
+	String type = "DEFAULT";
 
 	public void setPw(String encryptPassword) {
 		this.pw = encryptPassword;

--- a/src/main/resources/mapper/user/JoinMapper.xml
+++ b/src/main/resources/mapper/user/JoinMapper.xml
@@ -6,34 +6,31 @@
 <mapper namespace="com.flab.urlumberjack.user.mapper.UserMapper">
 
     <select id="selectUser" parameterType="String" resultType="com.flab.urlumberjack.user.domain.User">
-        SELECT *
+        SELECT tid
+             , email
+             , type
+             , status
+             , type
+             , role
         FROM user
         WHERE email = #{email}
     </select>
 
     <insert id="insertUser" parameterType="com.flab.urlumberjack.user.dto.request.JoinRequest">
-        INSERT INTO user(
-        email
-        , pw
-        , mdn
-        , status
-        , type
-        , join_dt
-        , update_dt)
-        VALUES ( #{email}
-        , #{pw}
-        , #{mdn}
-        , 'ACTIVE'
-        <choose>
-            <when test="type != null and !type.isEmpty()">
-                , #{type}
-            </when>
-            <otherwise>
-                , 'DEFAULT'
-            </otherwise>
-        </choose>
-        , NOW()
-        , NOW())
+        INSERT INTO user( email
+                        , pw
+                        , mdn
+                        , status
+                        , type
+                        , join_dt
+                        , update_dt)
+        VALUES (, #{email}
+               ,  #{pw}
+               ,  #{mdn}
+               ,  'ACTIVE'
+               ,  #{type}
+               ,  NOW()
+               ,  NOW())
     </insert>
 
 </mapper>

--- a/src/test/java/com/flab/urlumberjack/user/controller/UserControllerTest.java
+++ b/src/test/java/com/flab/urlumberjack/user/controller/UserControllerTest.java
@@ -32,6 +32,7 @@ import com.flab.urlumberjack.user.service.UserService;
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureMybatis
 @ExtendWith(MockitoExtension.class)
+@DisplayName("UserController 테스트")
 class UserControllerTest {
 
 	@Autowired

--- a/src/test/java/com/flab/urlumberjack/user/service/PwdEncodeTest.java
+++ b/src/test/java/com/flab/urlumberjack/user/service/PwdEncodeTest.java
@@ -1,11 +1,13 @@
 package com.flab.urlumberjack.user.service;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootTest
+@DisplayName("비밀번호 암호화 테스트")
 public class PwdEncodeTest {
 	@Autowired
 	PasswordEncoder passwordEncoder; // DI

--- a/src/test/java/com/flab/urlumberjack/user/service/UserServiceMockTest.java
+++ b/src/test/java/com/flab/urlumberjack/user/service/UserServiceMockTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import com.flab.urlumberjack.user.domain.User;
 import com.flab.urlumberjack.user.dto.request.JoinRequest;
@@ -20,7 +19,7 @@ import com.flab.urlumberjack.user.exception.NotExistedUserException;
 import com.flab.urlumberjack.user.mapper.UserMapper;
 
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
+@DisplayName("UserService Mock 테스트")
 class UserServiceMockTest {
 	@Mock
 	UserMapper mapper;

--- a/src/test/java/com/flab/urlumberjack/user/service/UserServiceTest.java
+++ b/src/test/java/com/flab/urlumberjack/user/service/UserServiceTest.java
@@ -3,14 +3,12 @@ package com.flab.urlumberjack.user.service;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-@ExtendWith(MockitoExtension.class)
 @SpringBootTest
+@DisplayName("UserService 테스트")
 class UserServiceTest {
 
 	@Autowired


### PR DESCRIPTION
1. UserController의 Join method mapping 수정 - post는 join의 의미를 가지고 있으며, user를 등록하는 api는 가입 하나뿐이므로 mapping을 controller mapping을 그대록 사용하도록 수정
2. 구체적이지 않은 이름을 가진 User domain값과 클래스 수정 - pw -> password - type -> UserJoinType - Status -> UserAccountStatus
3. insert 수행에 대한 성공/실패를 판별하는 global util 클래스 및 메서드 생성 - 회원가입 수행시에 사용
4. isDuplicatedEmail 메서드명을 checkDuplicatedEmail로 수정 - 조건 충족시, 반환값 없이 예외를 발생시키므로 좀더 알맞은 네이밍으로 수정
5. select 쿼리들 중, *를 사용하는 구문 수정
6. insertUser query에서 type값에 따른 choose구문 제거 - joinReqeust의 기본값을 DEFAULT로 설정해 불필요한 choose구문 제거
7. TestClass들에 DisplayName 어노테이션을 추가
8. 이전 커밋에서 분리했던 UserServiceTest, UserServiceMockTest에서 사용하지않는 불필요한 어노테이션 정리