### PR TITLE
[ # 6 ]  refresh token 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.1'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
-    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.0.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.1'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/flab/urlumberjack/UrlumberjackApplication.java
+++ b/src/main/java/com/flab/urlumberjack/UrlumberjackApplication.java
@@ -3,9 +3,11 @@ package com.flab.urlumberjack;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
 @MapperScan(basePackageClasses = UrlumberjackApplication.class)
+@EnableCaching
 public class UrlumberjackApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/flab/urlumberjack/global/config/SecurityConfig.java
+++ b/src/main/java/com/flab/urlumberjack/global/config/SecurityConfig.java
@@ -57,8 +57,8 @@ public class SecurityConfig {
 						"/api/v1/main/**",
 						"/api/v1/url/insert",
 						"/api/v1/url/select").permitAll()
-					.anyRequest().authenticated()
-			);
+					.anyRequest().authenticated())
+				.addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
 		return http.build();
 	}
 

--- a/src/main/java/com/flab/urlumberjack/global/jwt/JwtFilter.java
+++ b/src/main/java/com/flab/urlumberjack/global/jwt/JwtFilter.java
@@ -1,0 +1,32 @@
+package com.flab.urlumberjack.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+public class JwtFilter extends GenericFilterBean {
+
+    private final JwtProvider jwtProvider;
+
+    public JwtFilter(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException{
+        jwtProvider.resolveToken((HttpServletRequest)request).ifPresent(token -> {
+            if (jwtProvider.validateToken(token)) {
+                Authentication authentication = jwtProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        });
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/flab/urlumberjack/global/jwt/JwtProvider.java
+++ b/src/main/java/com/flab/urlumberjack/global/jwt/JwtProvider.java
@@ -5,6 +5,7 @@ import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -73,6 +74,14 @@ public class JwtProvider {
 	}
 
 	/**
+	 * Refresh token값 생성(UUID)
+	 * @return String : UUID
+	 */
+	public String generateRefreshToken() {
+		return UUID.randomUUID().toString();
+	}
+
+	/**
 	 * JWT에서 Authentication 객체 생성
 	 * @param token JWT
 	 * @return Authentication(token value)
@@ -97,8 +106,20 @@ public class JwtProvider {
 
 	/**
 	 * JWT에서 role 정보 추출
-	 * @param request HttpServletRequest
+	 * @param token HttpServletRequest
 	 * @return role(ADMIN, USER)
+	 */
+	public String getUserRole(String token) {
+		return (String)Jwts.parser()
+				.setSigningKey(secretKey)
+				.parseClaimsJws(token)
+				.getBody().get(ROLE);
+	}
+
+	/**
+	 * Request Header에서 token값 추출
+	 * @param request : HttpServletRequest
+	 * @return token값
 	 */
 	public Optional<String> resolveToken(HttpServletRequest request) {
 		return Optional.ofNullable(request.getHeader(AUTHORIZATION_HEADER));

--- a/src/main/java/com/flab/urlumberjack/global/jwt/domain/RefreshToken.java
+++ b/src/main/java/com/flab/urlumberjack/global/jwt/domain/RefreshToken.java
@@ -1,7 +1,13 @@
 package com.flab.urlumberjack.global.jwt.domain;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 public class RefreshToken {
 
 	private String email;

--- a/src/main/java/com/flab/urlumberjack/global/jwt/domain/RefreshToken.java
+++ b/src/main/java/com/flab/urlumberjack/global/jwt/domain/RefreshToken.java
@@ -1,0 +1,21 @@
+package com.flab.urlumberjack.global.jwt.domain;
+
+import java.time.LocalDateTime;
+
+public class RefreshToken {
+
+	private String email;
+	private String ip;
+	private String refreshToken;
+	private LocalDateTime expiredTime;
+
+	public static RefreshToken of(String email, String ip, String refreshToken, LocalDateTime expiredTime) {
+		RefreshToken token = new RefreshToken();
+		token.email = email;
+		token.ip = ip;
+		token.refreshToken = refreshToken;
+		token.expiredTime = expiredTime;
+		return token;
+	}
+
+}

--- a/src/main/java/com/flab/urlumberjack/global/jwt/domain/UserDetail.java
+++ b/src/main/java/com/flab/urlumberjack/global/jwt/domain/UserDetail.java
@@ -1,4 +1,4 @@
-package com.flab.urlumberjack.global.jwt;
+package com.flab.urlumberjack.global.jwt.domain;
 
 import java.util.Collection;
 

--- a/src/main/java/com/flab/urlumberjack/global/jwt/service/CacheService.java
+++ b/src/main/java/com/flab/urlumberjack/global/jwt/service/CacheService.java
@@ -1,0 +1,36 @@
+package com.flab.urlumberjack.global.jwt.service;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import com.flab.urlumberjack.global.jwt.domain.RefreshToken;
+
+@Service
+public class CacheService {
+
+	private static final Map<String, RefreshToken> REFRESH_CACHE_POOL = new ConcurrentHashMap<>();
+
+	private static final int expirationDate = 14;
+
+	@Cacheable(value = "refreshTokenCache", key = "#email")
+	public void saveRefreshToken(String email, String ip, String refreshToken) {
+		REFRESH_CACHE_POOL.put(email,
+			RefreshToken.of(email, ip, refreshToken, LocalDateTime.now().plusDays(expirationDate)));
+	}
+
+	@Cacheable(value = "refreshTokenCache", key = "#email")
+	public RefreshToken getRefreshToken(String email) {
+		return REFRESH_CACHE_POOL.get(email);
+	}
+
+	@CacheEvict(value = "refreshTokenCache", key = "#email")
+	public void removeToken(String email) {
+		REFRESH_CACHE_POOL.remove(email);
+	}ㅂ
+
+}

--- a/src/main/java/com/flab/urlumberjack/global/jwt/service/UserDetailService.java
+++ b/src/main/java/com/flab/urlumberjack/global/jwt/service/UserDetailService.java
@@ -1,10 +1,11 @@
-package com.flab.urlumberjack.global.jwt;
+package com.flab.urlumberjack.global.jwt.service;
 
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import com.flab.urlumberjack.global.jwt.domain.UserDetail;
 import com.flab.urlumberjack.user.domain.User;
 import com.flab.urlumberjack.user.exception.NotExistedUserException;
 import com.flab.urlumberjack.user.mapper.UserMapper;

--- a/src/main/java/com/flab/urlumberjack/user/controller/UserController.java
+++ b/src/main/java/com/flab/urlumberjack/user/controller/UserController.java
@@ -12,6 +12,7 @@ import com.flab.urlumberjack.user.dto.response.JoinResponse;
 import com.flab.urlumberjack.user.dto.response.LoginResponse;
 import com.flab.urlumberjack.user.service.UserService;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 
 @RestController
@@ -30,8 +31,9 @@ public class UserController {
 	}
 
 	@PostMapping("/login")
-	public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest dto) {
-		return ResponseEntity.ok(service.login(dto));
+	public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest dto, HttpServletRequest request) {
+		String ip = request.getRemoteAddr();
+		return ResponseEntity.ok(service.login(dto, ip));
 	}
 
 }

--- a/src/main/java/com/flab/urlumberjack/user/controller/UserController.java
+++ b/src/main/java/com/flab/urlumberjack/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.flab.urlumberjack.user.controller;
 
+import com.flab.urlumberjack.user.dto.request.ReIssueRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,6 +35,12 @@ public class UserController {
 	public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest dto, HttpServletRequest request) {
 		String ip = request.getRemoteAddr();
 		return ResponseEntity.ok(service.login(dto, ip));
+	}
+
+	@PostMapping("/reissue")
+	public ResponseEntity<LoginResponse> reissue(@RequestBody @Valid ReIssueRequest dto, HttpServletRequest request) {
+		String ip = request.getRemoteAddr();
+		return ResponseEntity.ok(service.reissue(dto, ip));
 	}
 
 }

--- a/src/main/java/com/flab/urlumberjack/user/dto/request/ReIssueRequest.java
+++ b/src/main/java/com/flab/urlumberjack/user/dto/request/ReIssueRequest.java
@@ -1,0 +1,11 @@
+package com.flab.urlumberjack.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReIssueRequest(
+        @NotBlank(message = "Access token이 없습니다.")
+        String accessToken,
+        @NotBlank(message = "Refresh token이 필요합니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/flab/urlumberjack/user/dto/response/LoginResponse.java
+++ b/src/main/java/com/flab/urlumberjack/user/dto/response/LoginResponse.java
@@ -1,14 +1,11 @@
 package com.flab.urlumberjack.user.dto.response;
 
+import com.flab.urlumberjack.global.jwt.domain.RefreshToken;
 import lombok.Builder;
 import lombok.Getter;
 
-@Getter
-@Builder
-public class LoginResponse {
-	private String accessToken;
-
-	public LoginResponse(String accessToken) {
-		this.accessToken = accessToken;
-	}
+public record LoginResponse (
+		String accessToken,
+		String refreshToken
+){
 }

--- a/src/main/java/com/flab/urlumberjack/user/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/flab/urlumberjack/user/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,14 @@
+package com.flab.urlumberjack.user.exception;
+
+import com.flab.urlumberjack.global.exception.CustomRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidRefreshTokenException extends CustomRuntimeException {
+
+    public static String message = "refresh token이 존재하지 않거나 유효하지 않습니다.";
+
+    public InvalidRefreshTokenException() {
+        super(message, HttpStatus.FORBIDDEN);
+    }
+
+}

--- a/src/main/java/com/flab/urlumberjack/user/service/UserService.java
+++ b/src/main/java/com/flab/urlumberjack/user/service/UserService.java
@@ -55,7 +55,7 @@ public class UserService {
 			.build();
 	}
 
-	public LoginResponse login(LoginRequest loginRequest) {
+	public LoginResponse login(LoginRequest loginRequest, String ip) {
 		User user = selectUserByEmail(loginRequest.getEmail());
 
 		if (!isMatchedPassword(loginRequest.getPw(), user.getPw())) {

--- a/src/test/java/com/flab/urlumberjack/user/controller/UserControllerTest.java
+++ b/src/test/java/com/flab/urlumberjack/user/controller/UserControllerTest.java
@@ -1,15 +1,23 @@
 package com.flab.urlumberjack.user.controller;
 
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.flab.urlumberjack.user.dto.request.ReIssueRequest;
+import com.flab.urlumberjack.user.dto.response.LoginResponse;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.BDDMockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mybatis.spring.boot.test.autoconfigure.AutoConfigureMybatis;
 import org.slf4j.Logger;
@@ -19,8 +27,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.util.ObjectUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,140 +46,193 @@ import com.flab.urlumberjack.user.service.UserService;
 @ExtendWith(MockitoExtension.class)
 class UserControllerTest {
 
+	@MockBean
+	private UserService userService;
+
 	@Autowired
 	private MockMvc mockMvc;
 	@Autowired
 	private ObjectMapper objectMapper;
-
-	@MockBean
-	UserService service;
 
 	public static final String VALID_EMAIL = "testUser@naver.com";
 	public static final String VALID_PW = "1q2w3e4r!";
 	public static final String VALID_MDN = "01011112222";
 
 	private final Logger log = LoggerFactory.getLogger(UserControllerTest.class);
+	@Nested
+	@DisplayName("로그인")
+	class LoginTest {
+		@Test
+		@DisplayName("조건에 맞는 모든 필드를 입력받으면 회원가입이 성공한다.")
+		void when_allFieldsAreEntered_expect_joinToSuccess() throws Exception {
+			JoinRequest joinRequest = JoinRequest.builder()
+					.email(VALID_EMAIL)
+					.pw(VALID_PW)
+					.mdn(VALID_MDN)
+					.build();
 
-	@Test
-	@DisplayName("조건에 맞는 모든 필드를 입력받으면 회원가입이 성공한다.")
-	void when_allFieldsAreEntered_expect_joinToSuccess() throws Exception {
-		JoinRequest joinRequest = JoinRequest.builder()
-			.email(VALID_EMAIL)
-			.pw(VALID_PW)
-			.mdn(VALID_MDN)
-			.build();
+			ResultActions response = mockMvc.perform(post("/api/v1/user/join")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsBytes(joinRequest))
+					)
+					.andDo(print());
 
-		ResultActions response = mockMvc.perform(post("/api/v1/user/join")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsBytes(joinRequest))
-			)
-			.andDo(print());
+			response.andExpect(status().isOk());
+		}
 
-		response.andExpect(status().isOk());
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {" ", "abc123", "gamil.com", "123!naver.com"})
+		@DisplayName("email 필드가 null, empty, blank 상태이거나 email형식이 아니라면 회원가입이 실패한다.")
+		void when_emailFieldIsNullAndEmptyAndBlank_expect_joinToFail(String email) throws Exception {
+			log.info("email: {}", email == null ? "null" : ObjectUtils.isEmpty(email) ? "empty" : email);
+			JoinRequest joinRequest = JoinRequest.builder()
+					.email(email)
+					.pw(VALID_PW)
+					.mdn(VALID_MDN)
+					.build();
+
+			ResultActions response = mockMvc.perform(post("/api/v1/user/join")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsBytes(joinRequest))
+					)
+					.andDo(print());
+
+			response.andExpect(status().isBadRequest());
+		}
+
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {" ", "a1!", "aaaaaaaaaa", "111111111", "!!!!!!!!!!",
+				"abcdef123456", "abcdef!@#$%^", "12345!@#$%", "abcedfg1234567!@#$%^&"})
+		@DisplayName("pw 필드가 null, empty, blank 상태이거나 pw형식에 어긋난다면 회원가입이 실패한다.")
+		void when_pwFieldIsNullAndEmptyAndBlank_expect_joinToFail(String pw) throws Exception {
+			log.info("email: {}", pw == null ? "null" : ObjectUtils.isEmpty(pw) ? "empty" : pw);
+			JoinRequest joinRequest = JoinRequest.builder()
+					.email(VALID_EMAIL)
+					.pw(pw)
+					.mdn(VALID_MDN)
+					.build();
+
+			ResultActions response = mockMvc.perform(post("/api/v1/user/join")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsBytes(joinRequest))
+					)
+					.andDo(print());
+
+			response.andExpect(status().isBadRequest());
+		}
+
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {" ", "0314723858", "+821011112222", "821011112222"})
+		@DisplayName("mdn 필드가 null, empty, blank 상태이거나 mdn형식에 위배된다면 회원가입이 실패한다.")
+		void when_mdnFieldIsNullAndEmptyAndBlank_expect_joinToFail(String mdn) throws Exception {
+			log.info("email: {}", mdn == null ? "null" : ObjectUtils.isEmpty(mdn) ? "empty" : mdn);
+			JoinRequest joinRequest = JoinRequest.builder()
+					.email(VALID_EMAIL)
+					.pw(VALID_PW)
+					.mdn(mdn)
+					.build();
+
+			ResultActions response = mockMvc.perform(post("/api/v1/user/join")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsBytes(joinRequest))
+					)
+					.andDo(print());
+
+			response.andExpect(status().isBadRequest());
+		}
+
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {" "})
+		@DisplayName("로그인시, email 필드가 null, empty, blank라면 로그인에 실패한다.")
+		void when_emailFieldIsNullAndEmptyAndBlank_expect_FailToLogin(String email) throws Exception {
+			log.info("email: {}", email == null ? "null" : ObjectUtils.isEmpty(email) ? "empty" : email);
+			LoginRequest loginRequest = LoginRequest.builder()
+					.email(email)
+					.pw(VALID_PW)
+					.build();
+
+			ResultActions response = mockMvc.perform(post("/api/v1/user/login")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsBytes(loginRequest))
+					)
+					.andDo(print());
+
+			response.andExpect(status().isBadRequest());
+		}
+
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {" "})
+		@DisplayName("로그인시, pw 필드가 null, empty, blank라면 로그인에 실패한다.")
+		void when_pwFieldIsNullAndEmptyAndBlank_expect_FailToLogin(String pw) throws Exception {
+			log.info("email: {}", pw == null ? "null" : ObjectUtils.isEmpty(pw) ? "empty" : pw);
+			LoginRequest loginRequest = LoginRequest.builder()
+					.email(VALID_EMAIL)
+					.pw(pw)
+					.build();
+
+			ResultActions response = mockMvc.perform(post("/api/v1/user/login")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsBytes(loginRequest))
+					)
+					.andDo(print());
+
+			response.andExpect(status().isBadRequest());
+		}
 	}
 
-	@ParameterizedTest
-	@NullAndEmptySource
-	@ValueSource(strings = {" ", "abc123", "gamil.com", "123!naver.com"})
-	@DisplayName("email 필드가 null, empty, blank 상태이거나 email형식이 아니라면 회원가입이 실패한다.")
-	void when_emailFieldIsNullAndEmptyAndBlank_expect_joinToFail(String email) throws Exception {
-		log.info("email: {}", email == null ? "null" : ObjectUtils.isEmpty(email) ? "empty" : email);
-		JoinRequest joinRequest = JoinRequest.builder()
-			.email(email)
-			.pw(VALID_PW)
-			.mdn(VALID_MDN)
-			.build();
+	@Nested
+	@DisplayName("액세스 토큰 재발급")
+	class ReissueTest {
+		@Test
+		@DisplayName("조건에 맞는 모든 필드를 입력받으면 access token 재발급이 성공한다.")
+		void when_allFieldsAreEntered_expects_reissueSuccess() throws Exception {
+			ReIssueRequest reIssueRequest = new ReIssueRequest("accessToken", "refreshToken");
 
-		ResultActions response = mockMvc.perform(post("/api/v1/user/join")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsBytes(joinRequest))
-			)
-			.andDo(print());
+			ResultActions response = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/user/reissue")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsBytes(reIssueRequest))
+					)
+					.andDo(print());
 
-		response.andExpect(status().isBadRequest());
-	}
+			response.andExpect(status().isOk());
+		}
 
-	@ParameterizedTest
-	@NullAndEmptySource
-	@ValueSource(strings = {" ", "a1!", "aaaaaaaaaa", "111111111", "!!!!!!!!!!",
-		"abcdef123456", "abcdef!@#$%^", "12345!@#$%", "abcedfg1234567!@#$%^&"})
-	@DisplayName("pw 필드가 null, empty, blank 상태이거나 pw형식에 어긋난다면 회원가입이 실패한다.")
-	void when_pwFieldIsNullAndEmptyAndBlank_expect_joinToFail(String pw) throws Exception {
-		log.info("email: {}", pw == null ? "null" : ObjectUtils.isEmpty(pw) ? "empty" : pw);
-		JoinRequest joinRequest = JoinRequest.builder()
-			.email(VALID_EMAIL)
-			.pw(pw)
-			.mdn(VALID_MDN)
-			.build();
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {" "})
+		@DisplayName("accessToken 필드가 null, empty, blank 상태라면 access token 재발급이 실패한다.")
+		void when_accessTokenFieldIsNullAndEmptyAndBlank_expect_loginFail(String accessToken) throws Exception {
+			ReIssueRequest reIssueRequest = new ReIssueRequest(accessToken, "refreshToken");
 
-		ResultActions response = mockMvc.perform(post("/api/v1/user/join")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsBytes(joinRequest))
-			)
-			.andDo(print());
+			ResultActions response = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/user/reissue")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsBytes(reIssueRequest))
+					)
+					.andDo(MockMvcResultHandlers.print());
 
-		response.andExpect(status().isBadRequest());
-	}
+			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+		}
 
-	@ParameterizedTest
-	@NullAndEmptySource
-	@ValueSource(strings = {" ", "0314723858", "+821011112222", "821011112222"})
-	@DisplayName("mdn 필드가 null, empty, blank 상태이거나 mdn형식에 위배된다면 회원가입이 실패한다.")
-	void when_mdnFieldIsNullAndEmptyAndBlank_expect_joinToFail(String mdn) throws Exception {
-		log.info("email: {}", mdn == null ? "null" : ObjectUtils.isEmpty(mdn) ? "empty" : mdn);
-		JoinRequest joinRequest = JoinRequest.builder()
-			.email(VALID_EMAIL)
-			.pw(VALID_PW)
-			.mdn(mdn)
-			.build();
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {" "})
+		@DisplayName("refreshToken 필드가 null, empty, blank 상태라면 access token 재발급이 실패한다.")
+		void when_refreshTokenFieldIsNullAndEmptyAndBlank_expect_loginFail(String refreshToken) throws Exception {
+			ReIssueRequest reIssueRequest = new ReIssueRequest("accessToken", refreshToken);
 
-		ResultActions response = mockMvc.perform(post("/api/v1/user/join")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsBytes(joinRequest))
-			)
-			.andDo(print());
+			ResultActions response = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/user/reissue")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsBytes(reIssueRequest))
+					)
+					.andDo(MockMvcResultHandlers.print());
 
-		response.andExpect(status().isBadRequest());
-	}
-
-	@ParameterizedTest
-	@NullAndEmptySource
-	@ValueSource(strings = {" "})
-	@DisplayName("로그인시, email 필드가 null, empty, blank라면 로그인에 실패한다.")
-	void when_emailFieldIsNullAndEmptyAndBlank_expect_FailToLogin(String email) throws Exception {
-		log.info("email: {}", email == null ? "null" : ObjectUtils.isEmpty(email) ? "empty" : email);
-		LoginRequest loginRequest = LoginRequest.builder()
-			.email(email)
-			.pw(VALID_PW)
-			.build();
-
-		ResultActions response = mockMvc.perform(post("/api/v1/user/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsBytes(loginRequest))
-			)
-			.andDo(print());
-
-		response.andExpect(status().isBadRequest());
-	}
-
-	@ParameterizedTest
-	@NullAndEmptySource
-	@ValueSource(strings = {" "})
-	@DisplayName("로그인시, pw 필드가 null, empty, blank라면 로그인에 실패한다.")
-	void when_pwFieldIsNullAndEmptyAndBlank_expect_FailToLogin(String pw) throws Exception {
-		log.info("email: {}", pw == null ? "null" : ObjectUtils.isEmpty(pw) ? "empty" : pw);
-		LoginRequest loginRequest = LoginRequest.builder()
-			.email(VALID_EMAIL)
-			.pw(pw)
-			.build();
-
-		ResultActions response = mockMvc.perform(post("/api/v1/user/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsBytes(loginRequest))
-			)
-			.andDo(print());
-
-		response.andExpect(status().isBadRequest());
+			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+		}
 	}
 
 }

--- a/src/test/java/com/flab/urlumberjack/user/service/UserServiceTest.java
+++ b/src/test/java/com/flab/urlumberjack/user/service/UserServiceTest.java
@@ -1,7 +1,11 @@
 package com.flab.urlumberjack.user.service;
 
+import com.flab.urlumberjack.global.jwt.JwtProvider;
+import com.flab.urlumberjack.global.jwt.service.CacheService;
+import com.flab.urlumberjack.user.exception.InvalidRefreshTokenException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,27 +23,71 @@ class UserServiceTest {
 	@Autowired
 	PasswordEncoder passwordEncoder;
 
-	@Test
-	@DisplayName("raw password와 encoded password가 일치하면 로그인이 성공한다.")
-	void whenPasswordMatched_expects_loginToSuccess() {
-		String password = "1q2w3e4r!";
-		String encodedPassword = passwordEncoder.encode(password);
+	@Autowired
+	JwtProvider jwtProvider;
 
-		Assertions.assertTrue(
-			service.isMatchedPassword(password, encodedPassword)
-		);
+	@Autowired
+	CacheService cacheService;
+
+	@Nested
+	@DisplayName("로그인")
+	class LoginTest {
+		@Test
+		@DisplayName("raw password와 encoded password가 일치하면 로그인이 성공한다.")
+		void whenPasswordMatched_expects_loginToSuccess() {
+			String password = "1q2w3e4r!";
+			String encodedPassword = passwordEncoder.encode(password);
+
+			Assertions.assertTrue(
+					service.isMatchedPassword(password, encodedPassword)
+			);
+		}
+
+		@Test
+		@DisplayName("raw password와 encoded password가 일치하지 않으면  로그인이 실패한다.")
+		void whenPasswordNotMatched_expects_loginToFail() {
+			String inputPassword = "1q2w3e4r!";
+			String savedPassword = "password";
+			String encodedPassword = passwordEncoder.encode(savedPassword);
+
+			Assertions.assertFalse(
+					service.isMatchedPassword(inputPassword, encodedPassword)
+			);
+		}
 	}
 
-	@Test
-	@DisplayName("raw password와 encoded password가 일치하지 않으면  로그인이 실패한다.")
-	void whenPasswordNotMatched_expects_loginToFail() {
-		String inputPassword = "1q2w3e4r!";
-		String savedPassword = "password";
-		String encodedPassword = passwordEncoder.encode(savedPassword);
+	@Nested
+	@DisplayName("액세스 토큰 재발급")
+	class ReissueTest {
+		@Test
+		@DisplayName("등록된 리프레시 토큰이 없다면 InvalidRefreshTokenException 발생한다.")
+		void when_tokenIsNotExisted_expect_throwsInvalidRefreshTokenException() {
+			String email = "test@test.com";
+			String ip = "123.123.123.123";
 
-		Assertions.assertFalse(
-			service.isMatchedPassword(inputPassword, encodedPassword)
-		);
+			cacheService.saveToken(email, ip, "refreshToken");
+
+			cacheService.deleteToken(email);
+
+			Assertions.assertThrows(InvalidRefreshTokenException.class, () -> {
+				service.validateRefreshToken(email, ip);
+			});
+		}
+
+		@Test
+		@DisplayName("등록된 리프레시 토큰과 이메일이 동일하지만 IP가 다르다면 InvalidRefreshTokenException 발생한다.")
+		void when_ipIsDifferent_expect_throwsInvalidRefreshTokenException() {
+			String email = "test@test.com";
+			String ip = "123.123.123.123";
+			String anotherIp = "321.321.321.321";
+
+			cacheService.saveToken(email, ip, "refreshToken");
+
+			Assertions.assertThrows(InvalidRefreshTokenException.class, () -> {
+				service.validateRefreshToken(email, anotherIp);
+			});
+		}
 	}
+
 
 }


### PR DESCRIPTION
1. spring cache로 구현하려고 했으나, 만료정책 설정이 불가능하여 카페인 캐시를 사용해 구현
2. security에서 권한이 필요한 api라면 access token이 유효한지 확인하는 작업 추가
3. 엑세스 토큰 재발급 및 리프레시 토큰 관련 테스트코드 추가